### PR TITLE
✨ [Feature] 마이페이지 관련 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	implementation 'io.springfox:springfox-swagger2:2.9.2'
 	implementation 'io.springfox:springfox-swagger-ui:2.9.2'

--- a/src/main/java/com/example/yaho/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/yaho/apiPayload/code/status/ErrorStatus.java
@@ -16,9 +16,11 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-
     // Game 오류
-    GAME_ID_NOT_FOUND(HttpStatus.FORBIDDEN, "GAME4001", "게임이 없습니다.");
+    GAME_ID_NOT_FOUND(HttpStatus.FORBIDDEN, "GAME4001", "게임이 없습니다."),
+
+    // Member 없음 오류
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/yaho/apiPayload/exception/handler/MemberHandler.java
+++ b/src/main/java/com/example/yaho/apiPayload/exception/handler/MemberHandler.java
@@ -1,0 +1,11 @@
+package com.example.yaho.apiPayload.exception.handler;
+
+import com.example.yaho.apiPayload.code.BaseErrorCode;
+import com.example.yaho.apiPayload.exception.GeneralException;
+
+public class MemberHandler extends GeneralException {
+
+    public MemberHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/yaho/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/example/yaho/aws/s3/AmazonS3Manager.java
@@ -24,7 +24,7 @@ public class AmazonS3Manager{
 
     private final UuidRepository uuidRepository;
 
-    public String uploadFile(String keyName, MultipartFile file){
+    public String uploadFile(String keyName, MultipartFile file) {
         String originalFilename = file.getOriginalFilename(); //원본 파일 명
         String extention = originalFilename.substring(originalFilename.lastIndexOf("."));
 
@@ -33,7 +33,7 @@ public class AmazonS3Manager{
         metadata.setContentType(file.getContentType());
         try {
             amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
-        }catch (IOException e){
+        } catch (IOException e){
             log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
         }
 

--- a/src/main/java/com/example/yaho/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/example/yaho/aws/s3/AmazonS3Manager.java
@@ -44,4 +44,7 @@ public class AmazonS3Manager{
         return amazonConfig.getMvpPath() + '/' + uuid.getUuid();
     }
 
+    public String generateProfileImgName(Uuid uuid) {
+        return amazonConfig.getProfileImg() + '/' + uuid.getUuid();
+    }
 }

--- a/src/main/java/com/example/yaho/config/AmazonConfig.java
+++ b/src/main/java/com/example/yaho/config/AmazonConfig.java
@@ -34,6 +34,9 @@ public class AmazonConfig {
     @Value("${cloud.aws.s3.path.mvp}")
     private String mvpPath;
 
+    @Value("${cloud.aws.s3.path.profileImg}")
+    private String profileImg;
+
     @PostConstruct
     public void init() {
         this.awsCredentials = new BasicAWSCredentials(accessKey, secretKey);

--- a/src/main/java/com/example/yaho/config/SecurityConfig.java
+++ b/src/main/java/com/example/yaho/config/SecurityConfig.java
@@ -1,35 +1,43 @@
-package com.example.yaho.config;
-
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.web.SecurityFilterChain;
-
-@Configuration
-@RequiredArgsConstructor
-@EnableWebSecurity
-public class SecurityConfig {
-
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/v2/api-docs", "/v3/api-docs", "/v3/api-docs/**", "/swagger-resources",
-                        "/swagger-resources/**", "/configuration/ui", "/configuration/security", "/swagger-ui/**",
-                        "/webjars/**", "/swagger-ui.html").permitAll()
-                        .anyRequest().authenticated()); // 일단 임시로 허용
-
-        return http.build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer(){
-        // 아래 url은 filter 에서 제외
-        return web ->
-                web.ignoring()
-                        .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**", "/auth/**");
-    }
-}
+//package com.example.yaho.config;
+//
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+//import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+//import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+//import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+//import org.springframework.security.config.http.SessionCreationPolicy;
+//import org.springframework.security.web.SecurityFilterChain;
+//
+//@Configuration
+//@RequiredArgsConstructor
+//@EnableWebSecurity
+//public class SecurityConfig {
+//
+//    @Bean
+//    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+//        http
+//                .csrf(AbstractHttpConfigurer::disable)
+//                .authorizeHttpRequests((authorizeRequests) -> {
+//                    authorizeRequests.anyRequest().permitAll();
+//                });
+//
+//        return http.build();
+//    }
+//
+//    @Bean
+//    public WebSecurityCustomizer webSecurityCustomizer(){
+//        return web ->
+//                web.ignoring().requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**");
+//    }
+//}
+//
+//
+//
+////        http
+////                .authorizeHttpRequests((auth) -> auth
+////                        .requestMatchers( "/swagger-resources",
+////                        "/swagger-resources/**", "/configuration/ui", "/configuration/security",
+////                        "/webjars/**", ).permitAll()
+////                        .anyRequest().authenticated()); // 일단 임시로 허용

--- a/src/main/java/com/example/yaho/config/SecurityConfig.java
+++ b/src/main/java/com/example/yaho/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.example.yaho.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/v2/api-docs", "/v3/api-docs", "/v3/api-docs/**", "/swagger-resources",
+                        "/swagger-resources/**", "/configuration/ui", "/configuration/security", "/swagger-ui/**",
+                        "/webjars/**", "/swagger-ui.html").permitAll()
+                        .anyRequest().authenticated()); // 일단 임시로 허용
+
+        return http.build();
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer(){
+        // 아래 url은 filter 에서 제외
+        return web ->
+                web.ignoring()
+                        .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**", "/auth/**");
+    }
+}

--- a/src/main/java/com/example/yaho/converter/MemberConverter.java
+++ b/src/main/java/com/example/yaho/converter/MemberConverter.java
@@ -1,0 +1,15 @@
+package com.example.yaho.converter;
+
+import com.example.yaho.domain.Member;
+import com.example.yaho.web.dto.MemberResponseDTO;
+
+public class MemberConverter {
+
+    public static MemberResponseDTO.memberProfileDTO toProfileDTO(Member member){
+
+        return MemberResponseDTO.memberProfileDTO.builder()
+                .nickname(member.getNickname())
+                .favoriteTeam(member.getFavoriteTeam())
+                .build();
+    }
+}

--- a/src/main/java/com/example/yaho/converter/MemberConverter.java
+++ b/src/main/java/com/example/yaho/converter/MemberConverter.java
@@ -1,7 +1,10 @@
 package com.example.yaho.converter;
 
+import com.example.yaho.domain.Diary;
 import com.example.yaho.domain.Member;
 import com.example.yaho.web.dto.MemberResponseDTO;
+
+import java.time.LocalDate;
 
 public class MemberConverter {
 
@@ -10,6 +13,17 @@ public class MemberConverter {
         return MemberResponseDTO.memberProfileDTO.builder()
                 .nickname(member.getNickname())
                 .favoriteTeam(member.getFavoriteTeam())
+                .build();
+    }
+
+    public static MemberResponseDTO.mypageDiaryDTO toDiaryDTO(Diary diary) {
+
+        return MemberResponseDTO.mypageDiaryDTO.builder()
+                .emotion(diary.getEmoticon())
+                .content(diary.getContent())
+                .location(diary.getLocation())
+                .date(diary.getDate())
+                .mvp(diary.getMvp())
                 .build();
     }
 }

--- a/src/main/java/com/example/yaho/domain/Member.java
+++ b/src/main/java/com/example/yaho/domain/Member.java
@@ -24,7 +24,7 @@ import java.time.format.DateTimeFormatter;
 public class Member extends BaseEntity {
 
     @Id
-//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(length = 50)

--- a/src/main/java/com/example/yaho/domain/Member.java
+++ b/src/main/java/com/example/yaho/domain/Member.java
@@ -1,15 +1,17 @@
 package com.example.yaho.domain;
 
 import com.example.yaho.domain.common.BaseEntity;
-import com.example.yaho.domain.enums.FairyGrade;
 import com.example.yaho.domain.enums.FavoriteTeam;
+import com.example.yaho.web.dto.MemberUpdateDTO;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Entity
 @Getter
@@ -50,4 +52,14 @@ public class Member extends BaseEntity {
     @Column(name = "updated_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime updatedAt;
 
+    // 멤버의 프로필 수정(닉네임, 최애구단)
+    public void update(MemberUpdateDTO memberUpdateDTO) {
+        this.nickname = memberUpdateDTO.getNickname();
+        this.favoriteTeam = memberUpdateDTO.getFavoriteTeam();
+    }
+
+    // 멤버의 프로필 이미지 수정
+    public void updateProfileImg(String profileImg){
+        this.profileImage = profileImg;
+    }
 }

--- a/src/main/java/com/example/yaho/domain/enums/FavoriteTeam.java
+++ b/src/main/java/com/example/yaho/domain/enums/FavoriteTeam.java
@@ -1,14 +1,14 @@
 package com.example.yaho.domain.enums;
 
 public enum FavoriteTeam {
-    KIA_TIGERS,
-    LG_TWINS,
-    SAMSUNG_LIONS,
     DOOSAN_BEARS,
-    SSG_LANDERS,
-    KT_WIZ,
-    NC_DINOS,
-    LOTTE_GIANTS,
     HANHWA_EAGLES,
-    KIWOOM_HEROES
+    KIA_TIGERS,
+    KIWOOM_HEROES,
+    KT_WIZ,
+    LG_TWINS,
+    LOTTE_GIANTS,
+    NC_DINOS,
+    SAMSUNG_LIONS,
+    SSG_LANDERS
 }

--- a/src/main/java/com/example/yaho/repository/DiaryRepository.java
+++ b/src/main/java/com/example/yaho/repository/DiaryRepository.java
@@ -4,7 +4,10 @@ import com.example.yaho.domain.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Diary findByDate(LocalDate date);
+
+    List<Diary> findTop9ByMember_IdOrderByDateDesc(Long memberId);
 }

--- a/src/main/java/com/example/yaho/repository/MemberRepository.java
+++ b/src/main/java/com/example/yaho/repository/MemberRepository.java
@@ -6,5 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
     Optional<Member> findByNickname(String nickname);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/example/yaho/service/MemberService/MemberService.java
+++ b/src/main/java/com/example/yaho/service/MemberService/MemberService.java
@@ -32,7 +32,6 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        Long id = member.getId();
         String nickname = member.getNickname();
         String profileImgUrl = member.getProfileImage();
         FavoriteTeam favoriteTeam = member.getFavoriteTeam();
@@ -81,5 +80,13 @@ public class MemberService {
                 .memberId(memberId)
                 .profileImgURL(imgURL)
                 .build();
+    }
+
+    /**
+     * 닉네임 중복 확인
+     */
+    public boolean checkNicknameExists(String nickname) {
+        boolean isExist = memberRepository.existsByNickname(nickname);
+        return isExist;
     }
 }

--- a/src/main/java/com/example/yaho/service/MemberService/MemberService.java
+++ b/src/main/java/com/example/yaho/service/MemberService/MemberService.java
@@ -1,40 +1,85 @@
 package com.example.yaho.service.MemberService;
 
+import com.example.yaho.apiPayload.code.status.ErrorStatus;
+import com.example.yaho.apiPayload.exception.handler.MemberHandler;
+import com.example.yaho.aws.s3.AmazonS3Manager;
+import com.example.yaho.converter.MemberConverter;
 import com.example.yaho.domain.Member;
+import com.example.yaho.domain.Uuid;
 import com.example.yaho.domain.enums.FavoriteTeam;
 import com.example.yaho.repository.MemberRepository;
 
+import com.example.yaho.repository.UuidRepository;
 import com.example.yaho.web.dto.MemberResponseDTO;
+import com.example.yaho.web.dto.MemberUpdateDTO;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class MemberService {
+
     private final MemberRepository memberRepository;
 
-    public Optional<Member> findById(Long memberId) {
-        return memberRepository.findById(memberId);
-    }
+    /**
+     * 프로필 조회
+     */
+    public MemberResponseDTO.memberProfileDTO getMemberProfile(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-    public MemberResponseDTO.memberProfileDTO getMemberProfile(String memberName) {
-
-        Member member = memberRepository.findByNickname(memberName).orElseThrow(()->{throw new IllegalArgumentException("멤버없음");});
-
-        Long memberId = member.getId();
+        Long id = member.getId();
         String nickname = member.getNickname();
         String profileImgUrl = member.getProfileImage();
         FavoriteTeam favoriteTeam = member.getFavoriteTeam();
 
         return MemberResponseDTO.memberProfileDTO.builder()
-                .memberId(memberId)
-                .nickName(nickname)
+                .nickname(nickname)
                 .profileImgUrl(profileImgUrl)
                 .favoriteTeam(favoriteTeam)
+                .build();
+    }
+
+    /***
+     * 프로필 수정(닉네임, 최애구단)
+     * @param memberUpdateDTO
+     * @return
+     */
+    public MemberResponseDTO.memberProfileDTO updateProfile(MemberUpdateDTO memberUpdateDTO, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        member.update(memberUpdateDTO);
+        memberRepository.save(member);
+
+        return MemberConverter.toProfileDTO(member);
+    }
+
+    private final AmazonS3Manager s3Manager;
+    private final UuidRepository uuidRepository;
+
+    /***
+     * 프로필 이미지 수정
+     * @param updateImg
+     * @param memberId
+     * @return
+     */
+    public MemberResponseDTO.ProfileImgDTO updateProfileImg(MemberUpdateDTO.profileImg updateImg, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Uuid imgUuid = uuidRepository.save(Uuid.builder().uuid(UUID.randomUUID().toString()).build());
+        String imgURL = s3Manager.uploadFile(s3Manager.generateProfileImgName(imgUuid), updateImg.getProfileImg());
+
+        member.updateProfileImg(imgURL);
+
+        return MemberResponseDTO.ProfileImgDTO.builder()
+                .memberId(memberId)
+                .profileImgURL(imgURL)
                 .build();
     }
 }

--- a/src/main/java/com/example/yaho/service/MemberService/MemberService.java
+++ b/src/main/java/com/example/yaho/service/MemberService/MemberService.java
@@ -1,6 +1,7 @@
 package com.example.yaho.service.MemberService;
 
 import com.example.yaho.domain.Member;
+import com.example.yaho.domain.enums.FavoriteTeam;
 import com.example.yaho.repository.MemberRepository;
 
 import com.example.yaho.web.dto.MemberResponseDTO;
@@ -16,6 +17,10 @@ import java.util.Optional;
 public class MemberService {
     private final MemberRepository memberRepository;
 
+    public Optional<Member> findById(Long memberId) {
+        return memberRepository.findById(memberId);
+    }
+
     public MemberResponseDTO.memberProfileDTO getMemberProfile(String memberName) {
 
         Member member = memberRepository.findByNickname(memberName).orElseThrow(()->{throw new IllegalArgumentException("멤버없음");});
@@ -23,11 +28,13 @@ public class MemberService {
         Long memberId = member.getId();
         String nickname = member.getNickname();
         String profileImgUrl = member.getProfileImage();
+        FavoriteTeam favoriteTeam = member.getFavoriteTeam();
 
         return MemberResponseDTO.memberProfileDTO.builder()
                 .memberId(memberId)
                 .nickName(nickname)
                 .profileImgUrl(profileImgUrl)
+                .favoriteTeam(favoriteTeam)
                 .build();
     }
 }

--- a/src/main/java/com/example/yaho/utils/SecurityUtil.java
+++ b/src/main/java/com/example/yaho/utils/SecurityUtil.java
@@ -1,27 +1,30 @@
-package com.example.yaho.utils;
-
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-
-public class SecurityUtil {
-
-    /* 현재 사용중인 유저의 id 가져오기
-    public static Long getCurrentUserId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null) { return null; }
-        Long userId = (Long) authentication.getPrincipal();
-
-        return userId;
-    }
-    */
-
-    // 현재 사용중인 유저의 nickname 가져오기
-    public static String getCurrentUserName() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || authentication.getName() == null) {
-            return null;
-        }
-        return authentication.getName();
-    }
-}
+//package com.example.yaho.utils;
+//
+//import org.springframework.security.core.Authentication;
+//import org.springframework.security.core.context.SecurityContextHolder;
+//import org.springframework.security.core.userdetails.UserDetails;
+//
+//import java.util.Optional;
+//
+//public class SecurityUtil {
+//
+//    // 현재 사용중인 유저의 nickname 가져오기
+//    public static String getCurrentUserName() {
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        if (authentication == null || authentication.getName() == null) {
+//            return null;
+//        }
+//        System.out.println("Authentication: " + authentication.getName());
+//        return authentication.getName();
+//    }
+//
+//    public static Optional<Object> getCurrentUserLogin() {
+//
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        if (authentication == null || authentication.getName() == null) {
+//            return Optional.empty();
+//        }
+//        System.out.println("Authentication: " + authentication.getName());
+//        return Optional.ofNullable(authentication.getPrincipal());
+//    }
+//}

--- a/src/main/java/com/example/yaho/web/controller/MemberController.java
+++ b/src/main/java/com/example/yaho/web/controller/MemberController.java
@@ -1,34 +1,85 @@
 package com.example.yaho.web.controller;
 
 import com.example.yaho.apiPayload.ApiResponse;
+import com.example.yaho.domain.Member;
+import com.example.yaho.repository.MemberRepository;
 import com.example.yaho.service.MemberService.MemberService;
-import com.example.yaho.utils.SecurityUtil;
+//import com.example.yaho.utils.SecurityUtil;
 import com.example.yaho.web.dto.MemberResponseDTO;
+import com.example.yaho.web.dto.MemberUpdateDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+import static org.apache.tomcat.util.http.fileupload.FileUploadBase.MULTIPART_FORM_DATA;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members")
 public class MemberController {
     private final MemberService memberService;
+    private final MemberRepository memberRepository;
 
-    @GetMapping
+    @GetMapping("/{memberId}")
     @Operation(summary = "멤버 조회 API",
-            description = "사용자의 닉네임과 프로필 이미지를 조회하는 API입니다")
+            description = "사용자의 닉네임과 프로필 이미지, 최애구단을 조회하는 API입니다")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content),
     })
-    public ApiResponse<MemberResponseDTO.memberProfileDTO> getMemberProfile() {
+    public ApiResponse<MemberResponseDTO.memberProfileDTO> getMemberProfile(@PathVariable Long memberId) {
 
-        String memberName = SecurityUtil.getCurrentUserName();
-        MemberResponseDTO.memberProfileDTO response = memberService.getMemberProfile(memberName);
+        Optional<Member> member = memberRepository.findById(memberId);
+
+        MemberResponseDTO.memberProfileDTO response = memberService.getMemberProfile(memberId);
+
+        return ApiResponse.onSuccess(response);
+    }
+
+    @PatchMapping("/profile/{memberId}")
+    @Operation(summary = "멤버 프로필 변경 API",
+            description = "사용자의 닉네임과 최애구단을 수정하는 API입니다")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content),
+    })
+    public ApiResponse<MemberResponseDTO.memberProfileDTO> updateMemberProfile(
+            @RequestBody MemberUpdateDTO memberUpdateDTO, @PathVariable Long memberId) {
+
+        Optional<Member> member = memberRepository.findById(memberId);
+
+        MemberResponseDTO.memberProfileDTO response = memberService.updateProfile(memberUpdateDTO, memberId);
+
+        return ApiResponse.onSuccess(response);
+    }
+
+    @PatchMapping(value = "/profile/img/{memberId}",
+            consumes = MULTIPART_FORM_DATA,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "멤버 프로필 이미지 변경 API",
+            description = "사용자의 프로필 이미지를 수정하는 API입니다")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content),
+    })
+    public ApiResponse<MemberResponseDTO.ProfileImgDTO> updateMemberProfileImg(
+            @ModelAttribute MemberUpdateDTO.profileImg updateImg, @PathVariable Long memberId) {
+
+        Optional<Member> member = memberRepository.findById(memberId);
+
+        MemberResponseDTO.ProfileImgDTO response = memberService.updateProfileImg(updateImg, memberId);
+
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/example/yaho/web/controller/MemberController.java
+++ b/src/main/java/com/example/yaho/web/controller/MemberController.java
@@ -22,6 +22,7 @@ import static org.apache.tomcat.util.http.fileupload.FileUploadBase.MULTIPART_FO
 @RequiredArgsConstructor
 @RequestMapping("/members")
 public class MemberController {
+
     private final MemberService memberService;
     private final MemberRepository memberRepository;
 
@@ -81,5 +82,19 @@ public class MemberController {
         MemberResponseDTO.ProfileImgDTO response = memberService.updateProfileImg(updateImg, memberId);
 
         return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/check/nickname")
+    @Operation(summary = "닉네임 중복 확인 API",
+            description = "중복되는 닉네임이 있는지 확인하는 API입니다. 이미 존재하는 닉네임이라면 true를, 아니라면 false를 반환합니다")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content),
+    })
+    public ApiResponse<Boolean> checkNickname(@RequestParam String nickname) {
+        Boolean isExist = memberService.checkNicknameExists(nickname);
+        return ApiResponse.onSuccess(isExist);
     }
 }

--- a/src/main/java/com/example/yaho/web/controller/MemberController.java
+++ b/src/main/java/com/example/yaho/web/controller/MemberController.java
@@ -37,14 +37,12 @@ public class MemberController {
     })
     public ApiResponse<MemberResponseDTO.memberProfileDTO> getMemberProfile(@PathVariable Long memberId) {
 
-        Optional<Member> member = memberRepository.findById(memberId);
-
         MemberResponseDTO.memberProfileDTO response = memberService.getMemberProfile(memberId);
 
         return ApiResponse.onSuccess(response);
     }
 
-    @PatchMapping("/profile/{memberId}")
+    @PatchMapping("/mypage/{memberId}")
     @Operation(summary = "멤버 프로필 변경 API",
             description = "사용자의 닉네임과 최애구단을 수정하는 API입니다")
     @ApiResponses({
@@ -56,14 +54,12 @@ public class MemberController {
     public ApiResponse<MemberResponseDTO.memberProfileDTO> updateMemberProfile(
             @RequestBody MemberUpdateDTO memberUpdateDTO, @PathVariable Long memberId) {
 
-        Optional<Member> member = memberRepository.findById(memberId);
-
         MemberResponseDTO.memberProfileDTO response = memberService.updateProfile(memberUpdateDTO, memberId);
 
         return ApiResponse.onSuccess(response);
     }
 
-    @PatchMapping(value = "/profile/img/{memberId}",
+    @PatchMapping(value = "/mypage/img/{memberId}",
             consumes = MULTIPART_FORM_DATA,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "멤버 프로필 이미지 변경 API",
@@ -76,8 +72,6 @@ public class MemberController {
     })
     public ApiResponse<MemberResponseDTO.ProfileImgDTO> updateMemberProfileImg(
             @ModelAttribute MemberUpdateDTO.profileImg updateImg, @PathVariable Long memberId) {
-
-        Optional<Member> member = memberRepository.findById(memberId);
 
         MemberResponseDTO.ProfileImgDTO response = memberService.updateProfileImg(updateImg, memberId);
 
@@ -96,5 +90,21 @@ public class MemberController {
     public ApiResponse<Boolean> checkNickname(@RequestParam String nickname) {
         Boolean isExist = memberService.checkNicknameExists(nickname);
         return ApiResponse.onSuccess(isExist);
+    }
+
+    @GetMapping("/mypage/diary/{memberId}")
+    @Operation(summary = "멤버의 일기 조회 API",
+            description = "사용자가 작성한 일기들을 9개만 조회하는 API입니다")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content),
+    })
+    public ApiResponse<MemberResponseDTO.mypageDiaryListDTO> getMemberDiary(@PathVariable Long memberId) {
+
+        MemberResponseDTO.mypageDiaryListDTO response = memberService.getMemberDiaryList(memberId);
+
+        return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/example/yaho/web/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/yaho/web/dto/MemberResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.yaho.web.dto;
 
+import com.example.yaho.domain.enums.FavoriteTeam;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,5 +16,6 @@ public class MemberResponseDTO {
         private Long memberId;
         private String nickName;
         private String profileImgUrl;
+        private FavoriteTeam favoriteTeam;
     }
 }

--- a/src/main/java/com/example/yaho/web/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/yaho/web/dto/MemberResponseDTO.java
@@ -6,6 +6,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public class MemberResponseDTO {
 
     @Builder
@@ -25,5 +28,24 @@ public class MemberResponseDTO {
     public static class ProfileImgDTO{
         private Long memberId;
         private String profileImgURL;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class mypageDiaryDTO { // 마이 페이지 중 일기 내용 DTO
+        String emotion;
+        String content;
+        String location;
+        LocalDate date;
+        String mvp;
+    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class mypageDiaryListDTO {
+        private List<mypageDiaryDTO> diaryList;
     }
 }

--- a/src/main/java/com/example/yaho/web/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/yaho/web/dto/MemberResponseDTO.java
@@ -13,9 +13,17 @@ public class MemberResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class memberProfileDTO {
-        private Long memberId;
-        private String nickName;
+        private String nickname;
         private String profileImgUrl;
         private FavoriteTeam favoriteTeam;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProfileImgDTO{
+        private Long memberId;
+        private String profileImgURL;
     }
 }

--- a/src/main/java/com/example/yaho/web/dto/MemberUpdateDTO.java
+++ b/src/main/java/com/example/yaho/web/dto/MemberUpdateDTO.java
@@ -1,0 +1,24 @@
+package com.example.yaho.web.dto;
+
+import com.example.yaho.domain.enums.FavoriteTeam;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberUpdateDTO {
+
+    private String nickname;
+    private FavoriteTeam favoriteTeam;
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class profileImg {
+        private MultipartFile profileImg;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,7 @@ cloud:
       bucket: yahobucket
       path:
         mvp : mvps
+        profileImg : profileImg
     region:
       static: ap-northeast-2
     stack:


### PR DESCRIPTION
1. member 객체 수정
- favoriteTeam의 type을 enum으로 수정
- common/enum에 team 추가

2. securityUtil, securityConfig
- pathvariable로 memberId를 불러오게 되어 사용하지 않으므로 주석 처리

3. 마이페이지
- 프로필 수정 api
- 프로필 이미지 수정 api
- 일기 조회 api : 해당 사용자의 일기를 최신순으로 9개 불러오는 api(직관 카드 관련 api)
- 닉네임 중복 확인 api