### PR TITLE
✨ [Feature] 감정 이모티콘, 구단 로고 불러오기 API 

### DIFF
--- a/src/main/java/com/example/yaho/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/yaho/apiPayload/code/status/ErrorStatus.java
@@ -18,7 +18,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
 
     // Game 오류
-    GAME_ID_NOT_FOUND(HttpStatus.FORBIDDEN, "GAME4001", "게임이 없습니다.");
+    GAME_ID_NOT_FOUND(HttpStatus.FORBIDDEN, "GAME4001", "게임이 없습니다."),
+
+    // Emotion 오류
+    EMOTION_NOT_FOUND(HttpStatus.NOT_FOUND, "EMOTION4001", "해당 이모티콘이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/yaho/converter/DiaryConverter.java
+++ b/src/main/java/com/example/yaho/converter/DiaryConverter.java
@@ -21,12 +21,20 @@ public class DiaryConverter {
 
         return Diary.builder()
                 .date(request.getDate())
-                .emoticon(request.getEmoticon())
+                .emotionImageUrl(request.getEmoticon())
                 .mvp(request.getMvp())  // 수정 가능성
                 .content(request.getContent())
                 .game(game) // Set the Game entity
                 .createdAt(now) // Set the created timestamp
                 .updatedAt(now) // Set the updated timestamp
+                .build();
+    }
+
+    public static DiaryResponseDTO.EmotionResultDTO toEmotionResultDTO(String emotionImageUrl, String favoriteClubImageUrl){
+
+        return DiaryResponseDTO.EmotionResultDTO.builder()
+                .emotionImageUrl(emotionImageUrl)
+                .FavoriteClubImageUrl(favoriteClubImageUrl)
                 .build();
     }
 }

--- a/src/main/java/com/example/yaho/domain/Diary.java
+++ b/src/main/java/com/example/yaho/domain/Diary.java
@@ -31,7 +31,7 @@ public class Diary {
     private LocalDate date;
 
     @Column(length = 255)
-    private String emoticon;
+    private String emotionImageUrl;
 
     @Column(length = 255)
     private String mvp;
@@ -39,7 +39,7 @@ public class Diary {
     @Column(length = 255)
     private String content;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_id") // 외래 키로 사용할 컬럼 이름
     private Game game; // Game 참조
 

--- a/src/main/java/com/example/yaho/domain/Game.java
+++ b/src/main/java/com/example/yaho/domain/Game.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 @Entity
 @Getter
@@ -27,6 +28,6 @@ public class Game {
     @Column(length = 30)
     private String location;
 
-    @OneToMany(mappedBy = "game") // Diary 엔티티에서 game 매핑됨
-    private List<Diary> diaries; // Diary 리스트
+    @OneToMany(mappedBy = "game", cascade = CascadeType.ALL) // Diary 엔티티에서 game 매핑됨
+    private List<Diary> diaries = new ArrayList<>(); // Diary 리스트
 }

--- a/src/main/java/com/example/yaho/domain/Member.java
+++ b/src/main/java/com/example/yaho/domain/Member.java
@@ -2,6 +2,7 @@ package com.example.yaho.domain;
 
 import com.example.yaho.domain.common.BaseEntity;
 import com.example.yaho.domain.enums.FairyGrade;
+import com.example.yaho.domain.enums.FavoriteClub;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
@@ -35,6 +36,9 @@ public class Member extends BaseEntity {
 
     @Column(name = "Field", length = 255)
     private String field;
+
+    @Enumerated(EnumType.STRING)
+    private FavoriteClub favoriteClub;
 
     @Enumerated(EnumType.STRING)
     private FairyGrade fairyGrade;

--- a/src/main/java/com/example/yaho/domain/enums/FavoriteClub.java
+++ b/src/main/java/com/example/yaho/domain/enums/FavoriteClub.java
@@ -1,0 +1,14 @@
+package com.example.yaho.domain.enums;
+
+public enum FavoriteClub {
+    SSG_LANDERS,
+    LG_TWINS,
+    KT_WIZ,
+    NC_DINOS,
+    DOOSAN_BEARS,
+    KIA_TIGERS,
+    LOTTE_GIANTS,
+    SAMSUNG_LIONS,
+    HANWHA_EAGLES,
+    KIWOOM_HEROES
+}

--- a/src/main/java/com/example/yaho/service/DiaryService/DiaryQueryService.java
+++ b/src/main/java/com/example/yaho/service/DiaryService/DiaryQueryService.java
@@ -1,0 +1,11 @@
+package com.example.yaho.service.DiaryService;
+
+import com.example.yaho.web.dto.DiaryRequestDTO;
+
+public interface DiaryQueryService {
+
+
+    String getEmotionImageUrl(DiaryRequestDTO.EmotionDto request);
+
+    String getFavoriteClubImageUrl(Long memberId);
+}

--- a/src/main/java/com/example/yaho/service/DiaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/com/example/yaho/service/DiaryService/DiaryQueryServiceImpl.java
@@ -19,7 +19,7 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
 
         String emotionImageUrl = "";
 
-        switch (request.getEmotionImage()) {
+        switch (request.getEmotionImage().intValue()) {
             case 1:
                 emotionImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/emotions/1.png";
                 break;

--- a/src/main/java/com/example/yaho/service/DiaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/com/example/yaho/service/DiaryService/DiaryQueryServiceImpl.java
@@ -1,0 +1,98 @@
+package com.example.yaho.service.DiaryService;
+
+import com.example.yaho.domain.Member;
+import com.example.yaho.repository.MemberRepository;
+import com.example.yaho.web.dto.DiaryRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiaryQueryServiceImpl implements DiaryQueryService{
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public String getEmotionImageUrl(DiaryRequestDTO.EmotionDto request) {
+
+        String emotionImageUrl = "";
+
+        switch (request.getEmotionImage()) {
+            case 1:
+                emotionImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/emotions/1.png";
+                break;
+            case 2:
+                emotionImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/emotions/2.png";
+                break;
+            case 3:
+                emotionImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/emotions/3.png";
+                break;
+            case 4:
+                emotionImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/emotions/4.png";
+                break;
+            case 5:
+                emotionImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/emotions/5.png";
+                break;
+            case 6:
+                emotionImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/emotions/6.png";
+                break;
+            case 7:
+                emotionImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/emotions/7.png";
+                break;
+            case 8:
+                emotionImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/emotions/8.png";
+                break;
+            case 9:
+                emotionImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/emotions/9.png";
+                break;
+        }
+        return emotionImageUrl;
+    }
+
+    @Override
+    public String getFavoriteClubImageUrl(Long memberId) {
+
+        Member member = memberRepository.findById(memberId).get();
+
+        String favoriteClubImageUrl = "";
+
+        switch (member.getFavoriteClub()) {
+            case SSG_LANDERS:
+                favoriteClubImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/clubs/SSG.png";
+                break;
+            case LG_TWINS:
+                favoriteClubImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/clubs/LG.png";
+                break;
+            case KT_WIZ:
+                favoriteClubImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/clubs/KT.png";
+                break;
+            case NC_DINOS:
+                favoriteClubImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/clubs/NC.png";
+                break;
+            case DOOSAN_BEARS:
+                favoriteClubImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/clubs/DOOSAN.png";
+                break;
+            case KIA_TIGERS:
+                favoriteClubImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/clubs/KIA.png";
+                break;
+            case LOTTE_GIANTS:
+                favoriteClubImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/clubs/LOTTE.png";
+                break;
+            case SAMSUNG_LIONS:
+                favoriteClubImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/clubs/SAMSUNG.png";
+                break;
+            case HANWHA_EAGLES:
+                favoriteClubImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/clubs/HANWHA.png";
+                break;
+            case KIWOOM_HEROES:
+                favoriteClubImageUrl = "https://yahobucket.s3.ap-northeast-2.amazonaws.com/clubs/KIWOOM.png";
+                break;
+        }
+        return favoriteClubImageUrl;
+
+    }
+
+
+}

--- a/src/main/java/com/example/yaho/validation/annotation/CheckEmotion.java
+++ b/src/main/java/com/example/yaho/validation/annotation/CheckEmotion.java
@@ -1,0 +1,18 @@
+package com.example.yaho.validation.annotation;
+
+import com.example.yaho.validation.validator.EmotionCheckValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = EmotionCheckValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckEmotion {
+
+    String message() default "이모티콘 요청으로 1~10 까지의 숫자를 입력하세요.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/example/yaho/validation/validator/EmotionCheckValidator.java
+++ b/src/main/java/com/example/yaho/validation/validator/EmotionCheckValidator.java
@@ -1,0 +1,27 @@
+package com.example.yaho.validation.validator;
+
+import com.example.yaho.apiPayload.code.status.ErrorStatus;
+import com.example.yaho.validation.annotation.CheckEmotion;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmotionCheckValidator implements ConstraintValidator<CheckEmotion, Integer> {
+    @Override
+    public void initialize(CheckEmotion constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        if (value < 1 || value > 9) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.EMOTION_NOT_FOUND.toString()).addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/example/yaho/web/controller/DiaryController.java
+++ b/src/main/java/com/example/yaho/web/controller/DiaryController.java
@@ -54,7 +54,7 @@ public class DiaryController {
         return ApiResponse.onSuccess(DiaryConverter.toWriteResultDTO(diary));
     }
 
-    @GetMapping("/{memberId}/emotion")
+    @PostMapping("/{memberId}/emotion")
     @Operation(summary = "특정 멤버의 이모티콘 이미지, 구단 로고 조회 API",description = "이모티콘은 1~9 까지의 숫자를 입력하면 해당 이미지가 Response 되도록 구현했습니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),

--- a/src/main/java/com/example/yaho/web/controller/DiaryController.java
+++ b/src/main/java/com/example/yaho/web/controller/DiaryController.java
@@ -4,28 +4,36 @@ import com.example.yaho.apiPayload.ApiResponse;
 import com.example.yaho.converter.DiaryConverter;
 import com.example.yaho.domain.Diary;
 import com.example.yaho.service.DiaryService.DiaryCommandService;
+import com.example.yaho.service.DiaryService.DiaryQueryService;
 import com.example.yaho.web.dto.DiaryRequestDTO;
 import com.example.yaho.web.dto.DiaryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Validated
+@RequiredArgsConstructor
 @RequestMapping("/diarys")
 public class DiaryController {
 
     private final DiaryCommandService diaryCommandService;
+    private final DiaryQueryService diaryQueryService;
 
-    // Constructor-based injection
-    @Autowired
-    public DiaryController(DiaryCommandService diaryCommandService) {
-        this.diaryCommandService = diaryCommandService;
-    }
+//    // Constructor-based injection
+//    @Autowired
+//    public DiaryController(DiaryCommandService diaryCommandService) {
+//        this.diaryCommandService = diaryCommandService;
+//    }
 
     @Operation(summary = "일기 쓰기 API", description = "작성한 일기를 저장하는 API입니다.")
     @PostMapping("/{gameId}/write")
@@ -45,4 +53,23 @@ public class DiaryController {
         Diary diary = diaryCommandService.writeDiary(gameId, request);
         return ApiResponse.onSuccess(DiaryConverter.toWriteResultDTO(diary));
     }
+
+    @GetMapping("/{memberId}/emotion")
+    @Operation(summary = "특정 멤버의 이모티콘 이미지, 구단 로고 조회 API",description = "이모티콘은 1~9 까지의 숫자를 입력하면 해당 이미지가 Response 되도록 구현했습니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "acess 토큰 만료",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "acess 토큰 모양이 이상함",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<DiaryResponseDTO.EmotionResultDTO> getEmotionImage(
+            @PathVariable(name = "memberId") Long memberId,
+            @RequestBody @Valid DiaryRequestDTO.EmotionDto request)
+    {
+        String emotionImageUrl = diaryQueryService.getEmotionImageUrl(request);
+        String favoriteClubImageUrl = diaryQueryService.getFavoriteClubImageUrl(memberId);
+        return ApiResponse.onSuccess(DiaryConverter.toEmotionResultDTO(emotionImageUrl, favoriteClubImageUrl));
+    }
+
+
 }

--- a/src/main/java/com/example/yaho/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/com/example/yaho/web/dto/DiaryRequestDTO.java
@@ -1,5 +1,6 @@
 package com.example.yaho.web.dto;
 
+import com.example.yaho.validation.annotation.CheckEmotion;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
@@ -30,6 +31,7 @@ public class DiaryRequestDTO {
     public static class EmotionDto{
 
         @NotNull
+        @CheckEmotion
         Integer emotionImage;
     }
 

--- a/src/main/java/com/example/yaho/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/com/example/yaho/web/dto/DiaryRequestDTO.java
@@ -17,4 +17,11 @@ public class DiaryRequestDTO {
         String content;
     }
 
+    @Getter
+    public static class EmotionDto{
+
+        @NotNull
+        Integer emotionImage;
+    }
+
 }

--- a/src/main/java/com/example/yaho/web/dto/DiaryResponseDTO.java
+++ b/src/main/java/com/example/yaho/web/dto/DiaryResponseDTO.java
@@ -13,4 +13,13 @@ public class DiaryResponseDTO {
         Long diaryId;
         LocalDateTime createdAt;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmotionResultDTO{
+        String emotionImageUrl;
+        String FavoriteClubImageUrl;
+    }
 }


### PR DESCRIPTION
1부터 9까지의 숫자(이모티콘)를 request 하면 그에 해당하는 이모티콘 이미지와 구단 로고를 response 하는 API 입니다. 
해당 이미지는 AWS S3에 올라가있는 이미지 url 을 string 형식으로 response 합니다. 

1부터 9까지의 숫자를 입력하지 않으면 오류가 발생하는 validation도 구현했습니다.
